### PR TITLE
Silence warnings for 7xxx versions of MESA

### DIFF
--- a/mesahub/install_mesa.sh
+++ b/mesahub/install_mesa.sh
@@ -24,6 +24,10 @@ then
     cd $mesa_source_dir/utils
     sed -i s/"USE_PGSTAR = YES"/"USE_PGSTAR = NO"/g makefile_header
     sed -i /"LOAD_PGPLOT ="/c\ "LOAD_PGPLOT =" makefile_header
+    if [[ $mesa_version =~ ^7 ]]
+    then
+        sed -i '/FCbasic = -fno-range-check/s/$/ -Wno-uninitialized/' makefile_header
+    fi
     cd ..
     ./clean
     ./install


### PR DESCRIPTION
Tested to work as expected. i.e. only changes makefile_header for versions starting with 7 and only comments where necessary. Full installs with this version of the script were tested and work.